### PR TITLE
[Task] bootstrap 원격 상태 스택 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.DS_Store
+
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 비용 최적화형 EKS 보안 실습 환경을 Terraform과 GitOps 기반으로 구성하기 위한 인프라 레포지토리
 
+## 추천 작업 순서
+1. 이슈 생성
+2. 라벨 및 프로젝트 지정
+3. 작업 상황 업데이트 및 시작일, 마감일 작성
+4. 브랜치 생성
+5. 작업 진행
+6. PR 생성 후 리뷰 요청
+
+## 저장소 구조
+- `bootstrap/`: Terraform 원격 상태 저장용 S3 버킷을 생성하는 영구 스택
+- `environments/dev/`: 실습 때마다 생성하고 삭제하는 개발 환경 루트 스택
+- `modules/`: VPC, EKS, 애드온, ArgoCD, namespace 정책을 단계적으로 쌓는 재사용 모듈
+- `manifests/`: 샘플 워크로드와 팀별 GitOps 매니페스트
+- `scripts/`: 클러스터 생성, 삭제, kubeconfig 설정 자동화 스크립트
+
+## 생명주기 원칙
+- `bootstrap`은 장기 유지하는 영구 인프라다.
+- `environments/dev`는 실습 목적에 맞춰 반복 생성과 삭제를 전제로 한다.
+
 ## 협업 규칙
 
 ### 이슈 작성 흐름
@@ -59,12 +78,3 @@
 - `feat/issue-12-eks-spot-node-group`
 - `fix/issue-18-argocd-sync-timeout`
 - `docs/issue-3-readme-collaboration-guide`
-
-## 추천 작업 순서
-1. 이슈 생성
-2. 라벨 및 프로젝트 지정
-3. 작업 상황 업데이트 및 시작일, 마감일 작성
-4. 브랜치 생성
-5. 작업 진행
-6. PR 생성 후 리뷰 요청
-

--- a/bootstrap/.terraform.lock.hcl
+++ b/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -1,0 +1,64 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+locals {
+  common_tags = merge(
+    {
+      Project     = var.project_name
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Owner       = var.owner
+      Lifecycle   = "bootstrap"
+    },
+    var.default_tags
+  )
+}
+
+provider "aws" {
+  region                      = var.aws_region
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_region_validation      = true
+  skip_requesting_account_id  = true
+}
+
+resource "aws_s3_bucket" "tfstate" {
+  bucket = var.tfstate_bucket_name
+
+  tags = local.common_tags
+}
+
+resource "aws_s3_bucket_versioning" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/bootstrap/outputs.tf
+++ b/bootstrap/outputs.tf
@@ -1,0 +1,14 @@
+output "tfstate_bucket_name" {
+  description = "S3 bucket name used for Terraform state storage."
+  value       = aws_s3_bucket.tfstate.bucket
+}
+
+output "tfstate_bucket_arn" {
+  description = "S3 bucket ARN used for Terraform state storage."
+  value       = aws_s3_bucket.tfstate.arn
+}
+
+output "aws_region" {
+  description = "AWS region configured for the bootstrap stack."
+  value       = var.aws_region
+}

--- a/bootstrap/terraform.tfvars
+++ b/bootstrap/terraform.tfvars
@@ -1,0 +1,12 @@
+project_name = "eks-security-infra"
+environment  = "bootstrap"
+aws_region   = "ap-northeast-2"
+owner        = "K8RVIS"
+
+# Replace with a globally unique bucket name before running terraform apply.
+tfstate_bucket_name = "eks-security-infra-tfstate-example"
+
+default_tags = {
+  Repository = "eks-security-infra"
+  ManagedBy  = "terraform"
+}

--- a/bootstrap/tests/bootstrap.tftest.hcl
+++ b/bootstrap/tests/bootstrap.tftest.hcl
@@ -1,0 +1,30 @@
+variables {
+  project_name        = "eks-security-infra"
+  environment         = "bootstrap"
+  aws_region          = "ap-northeast-2"
+  owner               = "K8RVIS"
+  tfstate_bucket_name = "eks-security-infra-tfstate-example"
+  default_tags = {
+    Repository = "eks-security-infra"
+    ManagedBy  = "terraform"
+  }
+}
+
+run "plan_creates_hardened_tfstate_bucket" {
+  command = plan
+
+  assert {
+    condition     = aws_s3_bucket.tfstate.bucket == var.tfstate_bucket_name
+    error_message = "tfstate bucket name must match the configured bucket name."
+  }
+
+  assert {
+    condition     = aws_s3_bucket_versioning.tfstate.versioning_configuration[0].status == "Enabled"
+    error_message = "tfstate bucket must enable versioning."
+  }
+
+  assert {
+    condition     = aws_s3_bucket_public_access_block.tfstate.block_public_acls && aws_s3_bucket_public_access_block.tfstate.block_public_policy
+    error_message = "tfstate bucket must block public access."
+  }
+}

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -1,0 +1,35 @@
+variable "project_name" {
+  description = "Project identifier used in tags and naming."
+  type        = string
+}
+
+variable "environment" {
+  description = "Lifecycle label for the bootstrap stack."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region for the bootstrap stack."
+  type        = string
+}
+
+variable "owner" {
+  description = "Owner tag applied to bootstrap resources."
+  type        = string
+}
+
+variable "tfstate_bucket_name" {
+  description = "Globally unique S3 bucket name for Terraform state."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.tfstate_bucket_name)) > 0
+    error_message = "tfstate_bucket_name must not be empty."
+  }
+}
+
+variable "default_tags" {
+  description = "Additional tags merged into the bootstrap stack."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #1

## 무엇을 만들었나요? (What)
- Terraform 원격 상태 저장용 S3 버킷 스택을 `bootstrap/`에 추가했습니다.
- 버전 관리, 서버사이드 암호화, 퍼블릭 액세스 차단이 포함된 기본 보안 설정을 적용했습니다.

## 왜 이렇게 만들었나요? (Why)
- 이후 `environments/dev`를 반복적으로 생성하고 삭제하려면 상태 저장소를 먼저 분리해야 하기 때문입니다.

## 검증
```
terraform fmt
terraform init -backend=false
terraform test
terraform validate
```
<img width="645" height="211" alt="image" src="https://github.com/user-attachments/assets/0d82f75d-9cef-4c55-946f-618e692ac759" />


## 참고
- 다음 단계에서는 `environments/dev`와 `modules/vpc`를 실제 apply 가능한 네트워크 스택으로 추가할 예정입니다.
