### PR TITLE
[Task] dev VPC 및 fck-nat 기반 구성 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.DS_Store
+
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 비용 최적화형 EKS 보안 실습 환경을 Terraform과 GitOps 기반으로 구성하기 위한 인프라 레포지토리
 
+## 추천 작업 순서
+1. 이슈 생성
+2. 라벨 및 프로젝트 지정
+3. 작업 상황 업데이트 및 시작일, 마감일 작성
+4. 브랜치 생성
+5. 작업 진행
+6. PR 생성 후 리뷰 요청
+
+## 저장소 구조
+- `bootstrap/`: Terraform 원격 상태 저장용 S3 버킷을 생성하는 영구 스택
+- `environments/dev/`: 실습 때마다 생성하고 삭제하는 개발 환경 루트 스택
+- `modules/`: VPC, EKS, 애드온, ArgoCD, namespace 정책을 단계적으로 쌓는 재사용 모듈
+- `manifests/`: 샘플 워크로드와 팀별 GitOps 매니페스트
+- `scripts/`: 클러스터 생성, 삭제, kubeconfig 설정 자동화 스크립트
+
+## 생명주기 원칙
+- `bootstrap`은 장기 유지하는 영구 인프라다.
+- `environments/dev`는 실습 목적에 맞춰 반복 생성과 삭제를 전제로 한다.
+
 ## 협업 규칙
 
 ### 이슈 작성 흐름
@@ -59,12 +78,3 @@
 - `feat/issue-12-eks-spot-node-group`
 - `fix/issue-18-argocd-sync-timeout`
 - `docs/issue-3-readme-collaboration-guide`
-
-## 추천 작업 순서
-1. 이슈 생성
-2. 라벨 및 프로젝트 지정
-3. 작업 상황 업데이트 및 시작일, 마감일 작성
-4. 브랜치 생성
-5. 작업 진행
-6. PR 생성 후 리뷰 요청
-

--- a/bootstrap/.terraform.lock.hcl
+++ b/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -1,0 +1,64 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+locals {
+  common_tags = merge(
+    {
+      Project     = var.project_name
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Owner       = var.owner
+      Lifecycle   = "bootstrap"
+    },
+    var.default_tags
+  )
+}
+
+provider "aws" {
+  region                      = var.aws_region
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_region_validation      = true
+  skip_requesting_account_id  = true
+}
+
+resource "aws_s3_bucket" "tfstate" {
+  bucket = var.tfstate_bucket_name
+
+  tags = local.common_tags
+}
+
+resource "aws_s3_bucket_versioning" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/bootstrap/outputs.tf
+++ b/bootstrap/outputs.tf
@@ -1,0 +1,14 @@
+output "tfstate_bucket_name" {
+  description = "S3 bucket name used for Terraform state storage."
+  value       = aws_s3_bucket.tfstate.bucket
+}
+
+output "tfstate_bucket_arn" {
+  description = "S3 bucket ARN used for Terraform state storage."
+  value       = aws_s3_bucket.tfstate.arn
+}
+
+output "aws_region" {
+  description = "AWS region configured for the bootstrap stack."
+  value       = var.aws_region
+}

--- a/bootstrap/terraform.tfvars
+++ b/bootstrap/terraform.tfvars
@@ -1,0 +1,12 @@
+project_name = "eks-security-infra"
+environment  = "bootstrap"
+aws_region   = "ap-northeast-2"
+owner        = "K8RVIS"
+
+# Replace with a globally unique bucket name before running terraform apply.
+tfstate_bucket_name = "eks-security-infra-tfstate-example"
+
+default_tags = {
+  Repository = "eks-security-infra"
+  ManagedBy  = "terraform"
+}

--- a/bootstrap/tests/bootstrap.tftest.hcl
+++ b/bootstrap/tests/bootstrap.tftest.hcl
@@ -1,0 +1,30 @@
+variables {
+  project_name        = "eks-security-infra"
+  environment         = "bootstrap"
+  aws_region          = "ap-northeast-2"
+  owner               = "K8RVIS"
+  tfstate_bucket_name = "eks-security-infra-tfstate-example"
+  default_tags = {
+    Repository = "eks-security-infra"
+    ManagedBy  = "terraform"
+  }
+}
+
+run "plan_creates_hardened_tfstate_bucket" {
+  command = plan
+
+  assert {
+    condition     = aws_s3_bucket.tfstate.bucket == var.tfstate_bucket_name
+    error_message = "tfstate bucket name must match the configured bucket name."
+  }
+
+  assert {
+    condition     = aws_s3_bucket_versioning.tfstate.versioning_configuration[0].status == "Enabled"
+    error_message = "tfstate bucket must enable versioning."
+  }
+
+  assert {
+    condition     = aws_s3_bucket_public_access_block.tfstate.block_public_acls && aws_s3_bucket_public_access_block.tfstate.block_public_policy
+    error_message = "tfstate bucket must block public access."
+  }
+}

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -1,0 +1,35 @@
+variable "project_name" {
+  description = "Project identifier used in tags and naming."
+  type        = string
+}
+
+variable "environment" {
+  description = "Lifecycle label for the bootstrap stack."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region for the bootstrap stack."
+  type        = string
+}
+
+variable "owner" {
+  description = "Owner tag applied to bootstrap resources."
+  type        = string
+}
+
+variable "tfstate_bucket_name" {
+  description = "Globally unique S3 bucket name for Terraform state."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.tfstate_bucket_name)) > 0
+    error_message = "tfstate_bucket_name must not be empty."
+  }
+}
+
+variable "default_tags" {
+  description = "Additional tags merged into the bootstrap stack."
+  type        = map(string)
+  default     = {}
+}

--- a/environments/dev/backend.tf
+++ b/environments/dev/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    use_lockfile = true
+  }
+}

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -1,0 +1,14 @@
+module "vpc" {
+  source = "../../modules/vpc"
+
+  project_name          = var.project_name
+  environment           = var.environment
+  aws_region            = var.aws_region
+  owner                 = var.owner
+  vpc_cidr              = var.vpc_cidr
+  availability_zones    = var.availability_zones
+  public_subnet_cidrs   = var.public_subnet_cidrs
+  private_subnet_cidrs  = var.private_subnet_cidrs
+  fck_nat_instance_type = var.fck_nat_instance_type
+  default_tags          = var.default_tags
+}

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -1,0 +1,29 @@
+output "vpc_id" {
+  description = "VPC ID for the dev environment."
+  value       = module.vpc.vpc_id
+}
+
+output "vpc_cidr" {
+  description = "CIDR block for the dev VPC."
+  value       = module.vpc.vpc_cidr
+}
+
+output "public_subnet_ids" {
+  description = "Ordered list of public subnet IDs."
+  value       = module.vpc.public_subnet_ids
+}
+
+output "private_subnet_ids" {
+  description = "Ordered list of private subnet IDs."
+  value       = module.vpc.private_subnet_ids
+}
+
+output "fck_nat_instance_id" {
+  description = "Instance ID of the fck-nat instance."
+  value       = module.vpc.fck_nat_instance_id
+}
+
+output "fck_nat_ami_id" {
+  description = "Automatically selected AMI ID for the fck-nat instance."
+  value       = module.vpc.fck_nat_ami_id
+}

--- a/environments/dev/providers.tf
+++ b/environments/dev/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/environments/dev/terraform.tfvars
+++ b/environments/dev/terraform.tfvars
@@ -1,0 +1,28 @@
+project_name = "eks-security-infra"
+environment  = "dev"
+aws_region   = "ap-northeast-2"
+owner        = "K8RVIS"
+
+vpc_cidr = "10.0.0.0/16"
+
+availability_zones = [
+  "ap-northeast-2a",
+  "ap-northeast-2c",
+]
+
+public_subnet_cidrs = [
+  "10.0.1.0/24",
+  "10.0.2.0/24",
+]
+
+private_subnet_cidrs = [
+  "10.0.10.0/24",
+  "10.0.20.0/24",
+]
+
+fck_nat_instance_type = "t4g.nano"
+
+default_tags = {
+  Repository = "eks-security-infra"
+  ManagedBy  = "terraform"
+}

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -1,0 +1,51 @@
+variable "project_name" {
+  description = "Project identifier used in tags and naming."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name for the dev stack."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region for the dev stack."
+  type        = string
+}
+
+variable "owner" {
+  description = "Owner tag applied to dev resources."
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the dev VPC."
+  type        = string
+}
+
+variable "availability_zones" {
+  description = "Availability zones used for the two-AZ VPC layout."
+  type        = list(string)
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets ordered by availability zone."
+  type        = list(string)
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private subnets ordered by availability zone."
+  type        = list(string)
+}
+
+variable "fck_nat_instance_type" {
+  description = "Instance type for the fck-nat instance."
+  type        = string
+  default     = "t4g.nano"
+}
+
+variable "default_tags" {
+  description = "Additional tags merged into all dev resources."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/vpc/fck-nat.tf
+++ b/modules/vpc/fck-nat.tf
@@ -1,0 +1,85 @@
+data "aws_ami" "fck_nat" {
+  most_recent = true
+  owners      = ["568608671756"]
+
+  filter {
+    name   = "name"
+    values = ["fck-nat-al2023-*-arm64-ebs"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_security_group" "fck_nat" {
+  name        = "${var.project_name}-${var.environment}-fck-nat"
+  description = "Security group for the fck-nat instance"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description = "Allow private subnet traffic to be NATed"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    description = "Allow outbound internet traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-fck-nat-sg"
+    }
+  )
+}
+
+resource "aws_instance" "fck_nat" {
+  ami                         = data.aws_ami.fck_nat.id
+  instance_type               = var.fck_nat_instance_type
+  subnet_id                   = aws_subnet.public[local.nat_az].id
+  associate_public_ip_address = true
+  source_dest_check           = false
+  vpc_security_group_ids      = [aws_security_group.fck_nat.id]
+
+  instance_market_options {
+    market_type = "spot"
+
+    spot_options {
+      instance_interruption_behavior = "terminate"
+      spot_instance_type             = "one-time"
+    }
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-fck-nat"
+      Role = "fck-nat"
+    }
+  )
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,0 +1,133 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+locals {
+  common_tags = merge(
+    {
+      Project     = var.project_name
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Owner       = var.owner
+      Module      = "vpc"
+    },
+    var.default_tags
+  )
+
+  public_subnets  = zipmap(var.availability_zones, var.public_subnet_cidrs)
+  private_subnets = zipmap(var.availability_zones, var.private_subnet_cidrs)
+  nat_az          = var.availability_zones[0]
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-vpc"
+    }
+  )
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-igw"
+    }
+  )
+}
+
+resource "aws_subnet" "public" {
+  for_each = local.public_subnets
+
+  vpc_id                  = aws_vpc.this.id
+  availability_zone       = each.key
+  cidr_block              = each.value
+  map_public_ip_on_launch = true
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name                     = "${var.project_name}-${var.environment}-public-${each.key}"
+      Tier                     = "public"
+      "kubernetes.io/role/elb" = "1"
+    }
+  )
+}
+
+resource "aws_subnet" "private" {
+  for_each = local.private_subnets
+
+  vpc_id                  = aws_vpc.this.id
+  availability_zone       = each.key
+  cidr_block              = each.value
+  map_public_ip_on_launch = false
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name                              = "${var.project_name}-${var.environment}-private-${each.key}"
+      Tier                              = "private"
+      "kubernetes.io/role/internal-elb" = "1"
+    }
+  )
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-public-rt"
+    }
+  )
+}
+
+resource "aws_route" "public_default" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table_association" "public" {
+  for_each = aws_subnet.public
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.project_name}-${var.environment}-private-rt"
+    }
+  )
+}
+
+resource "aws_route" "private_default" {
+  route_table_id         = aws_route_table.private.id
+  destination_cidr_block = "0.0.0.0/0"
+  network_interface_id   = aws_instance.fck_nat.primary_network_interface_id
+}
+
+resource "aws_route_table_association" "private" {
+  for_each = aws_subnet.private
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private.id
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,0 +1,49 @@
+output "vpc_id" {
+  description = "VPC ID for the dev environment."
+  value       = aws_vpc.this.id
+}
+
+output "vpc_cidr" {
+  description = "CIDR block for the VPC."
+  value       = aws_vpc.this.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "Ordered list of public subnet IDs."
+  value       = [for az in var.availability_zones : aws_subnet.public[az].id]
+}
+
+output "private_subnet_ids" {
+  description = "Ordered list of private subnet IDs."
+  value       = [for az in var.availability_zones : aws_subnet.private[az].id]
+}
+
+output "public_subnet_cidrs" {
+  description = "Ordered list of public subnet CIDR blocks."
+  value       = [for az in var.availability_zones : aws_subnet.public[az].cidr_block]
+}
+
+output "private_subnet_cidrs" {
+  description = "Ordered list of private subnet CIDR blocks."
+  value       = [for az in var.availability_zones : aws_subnet.private[az].cidr_block]
+}
+
+output "public_route_table_id" {
+  description = "Public route table ID."
+  value       = aws_route_table.public.id
+}
+
+output "private_route_table_id" {
+  description = "Private route table ID."
+  value       = aws_route_table.private.id
+}
+
+output "fck_nat_instance_id" {
+  description = "Instance ID of the fck-nat instance."
+  value       = aws_instance.fck_nat.id
+}
+
+output "fck_nat_ami_id" {
+  description = "Automatically selected AMI ID for the fck-nat instance."
+  value       = data.aws_ami.fck_nat.id
+}

--- a/modules/vpc/tests/network-layout.tftest.hcl
+++ b/modules/vpc/tests/network-layout.tftest.hcl
@@ -1,0 +1,73 @@
+mock_provider "aws" {
+  override_during = plan
+}
+
+variables {
+  project_name          = "eks-security-infra"
+  environment           = "dev"
+  aws_region            = "ap-northeast-2"
+  owner                 = "K8RVIS"
+  vpc_cidr              = "10.0.0.0/16"
+  availability_zones    = ["ap-northeast-2a", "ap-northeast-2c"]
+  public_subnet_cidrs   = ["10.0.1.0/24", "10.0.2.0/24"]
+  private_subnet_cidrs  = ["10.0.10.0/24", "10.0.20.0/24"]
+  fck_nat_instance_type = "t4g.nano"
+  default_tags = {
+    Repository = "eks-security-infra"
+    ManagedBy  = "terraform"
+  }
+}
+
+run "creates_expected_network_layout" {
+  command = apply
+
+  assert {
+    condition     = aws_vpc.this.cidr_block == "10.0.0.0/16"
+    error_message = "VPC CIDR must match the documented 10.0.0.0/16 range."
+  }
+
+  assert {
+    condition     = length(aws_subnet.public) == 2
+    error_message = "Two public subnets must be created for the two-AZ layout."
+  }
+
+  assert {
+    condition     = length(aws_subnet.private) == 2
+    error_message = "Two private subnets must be created for worker nodes."
+  }
+
+  assert {
+    condition     = aws_subnet.public["ap-northeast-2a"].cidr_block == "10.0.1.0/24"
+    error_message = "Public subnet A must use 10.0.1.0/24."
+  }
+
+  assert {
+    condition     = aws_subnet.private["ap-northeast-2c"].cidr_block == "10.0.20.0/24"
+    error_message = "Private subnet B must use 10.0.20.0/24."
+  }
+
+  assert {
+    condition     = aws_instance.fck_nat.subnet_id == aws_subnet.public["ap-northeast-2a"].id
+    error_message = "fck-nat must be placed in Public Subnet A."
+  }
+
+  assert {
+    condition     = aws_instance.fck_nat.instance_type == "t4g.nano"
+    error_message = "fck-nat must default to the documented t4g.nano instance type."
+  }
+
+  assert {
+    condition     = aws_instance.fck_nat.ami == data.aws_ami.fck_nat.id
+    error_message = "fck-nat must use the automatically discovered official AMI."
+  }
+
+  assert {
+    condition     = aws_instance.fck_nat.source_dest_check == false
+    error_message = "fck-nat must disable source/destination checks."
+  }
+
+  assert {
+    condition     = aws_route.private_default.network_interface_id == aws_instance.fck_nat.primary_network_interface_id
+    error_message = "Private subnet default route must point to the fck-nat primary network interface."
+  }
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -1,0 +1,66 @@
+variable "project_name" {
+  description = "Project identifier used in tags and naming."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name used in tags and naming."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region for the VPC stack."
+  type        = string
+}
+
+variable "owner" {
+  description = "Owner tag applied to VPC resources."
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC."
+  type        = string
+}
+
+variable "availability_zones" {
+  description = "Availability zones used for the two-AZ network layout."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.availability_zones) == 2
+    error_message = "Exactly two availability zones must be supplied for the documented layout."
+  }
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets ordered by availability zone."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.public_subnet_cidrs) == 2
+    error_message = "Exactly two public subnet CIDRs must be supplied."
+  }
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private subnets ordered by availability zone."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.private_subnet_cidrs) == 2
+    error_message = "Exactly two private subnet CIDRs must be supplied."
+  }
+}
+
+variable "fck_nat_instance_type" {
+  description = "Instance type for the fck-nat instance."
+  type        = string
+  default     = "t4g.nano"
+}
+
+variable "default_tags" {
+  description = "Additional tags merged into all VPC resources."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #3

## 무엇을 만들었나요? (What)
- `environments/dev`를 실제로 apply 가능한 루트 모듈로 추가했습니다.
- `modules/vpc`에 VPC, Public Subnet 2개, Private Subnet 2개, IGW, public/private route table 구성을 추가했습니다.
- Public Subnet A에 Spot 기반 `fck-nat` 인스턴스를 배치하고, private subnet 기본 라우트를 NAT 인스턴스로 연결했습니다.
- `fck-nat` AMI는 수동 입력 대신 공식 owner 기준 최신 arm64 이미지를 자동 조회하도록 구성했습니다.
- VPC 네트워크 레이아웃과 NAT 연결을 검증하는 Terraform 테스트를 추가했습니다.

## 왜 이렇게 만들었나요? (Why)
- `environments/dev`가 실제 리소스를 생성하는 실행 가능한 루트 모듈로 만들었습니다.
- EKS를 올리기 전에 네트워크 구조와 outbound 경로를 먼저 테스트를 할 수 있도록 분리했습니다.

## 검증

### AWS 계정 로그인
```
aws configure sso --profile eks-security-infra

SSO session name (Recommended): eks-security-infra
SSO start URL [None]: <전달밭은 SSO의 start URL>
SSO region [None]: ap-northeast-2
SSO registration scopes [sso:account:access]: <엔터 입력>

aws sso login --profile eks-security-infra
aws sts get-caller-identity --profile eks-security-infra

export AWS_PROFILE=eks-security-infra
export AWS_REGION=ap-northeast-2
export AWS_DEFAULT_REGION=ap-northeast-2
```

### bootstrap 동작 확인
```
terraform -chdir=bootstrap init -backend=false
terraform -chdir=bootstrap test
terraform -chdir=bootstrap validate
terraform -chdir=bootstrap plan
terraform -chdir=bootstrap apply
```
<img width="1996" height="616" alt="image" src="https://github.com/user-attachments/assets/622ae6be-cab8-42e9-831d-c6205fd5eed2" />
버킷 이름은 bootstrap/terraform.tfvars에서 `tfstate_bucket_name`을 변경하면 됩니다.

### environments 동작 확인
```
terraform -chdir=environments/dev init -reconfigure \
  -backend-config="bucket=<생성한 버킷명>" \
  -backend-config="key=environments/dev/terraform.tfstate" \
  -backend-config="region=ap-northeast-2"

terraform -chdir=modules/vpc init -backend=false
terraform -chdir=modules/vpc test
terraform -chdir=environments/dev validate
terraform -chdir=environments/dev plan
terraform -chdir=environments/dev apply
```
<img width="1544" height="855" alt="스크린샷 2026-04-02 오전 3 24 49" src="https://github.com/user-attachments/assets/4161728a-45eb-473f-8e4e-cb0875b252f0" />
VPC 생성 확인

<img width="967" height="211" alt="스크린샷 2026-04-02 오전 3 25 10" src="https://github.com/user-attachments/assets/ad02403d-4f3e-4533-80f3-0aef509dffbe" />
fck-nat 생성 확인

### 실습 환경 삭제
```
terraform -chdir=environments/dev destroy
terraform -chdir=bootstrap destroy # 생성된 S3 내부의 파일은 수동으로 삭제가 필요할 수 있음
```

## 참고
- 이번 PR은 VPC와 NAT 기반까지만 포함하며, EKS 클러스터와 IAM 접근 제어는 다음 PR에서 추가합니다.
